### PR TITLE
Enhance Keyboard Notifications Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 add in package.json
 ```sh
-"react-native-safe-area-ime": "sergeymild/react-native-safe-area-ime#0.7.2"
+"react-native-safe-area-ime": "sergeymild/react-native-safe-area-ime#0.8.0"
 ```
 
 ## Usage

--- a/android/src/main/cpp/SafeArea.cpp
+++ b/android/src/main/cpp/SafeArea.cpp
@@ -78,10 +78,13 @@ void SafeArea::installJSIBindings() {
                  std::shared_ptr<jsi::Function> c = (*cc)["listenKeyboard"];
                  if (!c) return;
 
-                 jsi::Object object = jsi::Object(*r);
-                 object.setProperty(*r, "type", jsi::String::createFromUtf8(*r, type));
-                 object.setProperty(*r, "height", jsi::Value(height));
+                 std::string keyboardState = type == "show" ? "OPENED" : "CLOSED";
+                 bool isKeyboardPresent = keyboardState == "OPENED";
 
+                 jsi::Object object = jsi::Object(*r);
+                 object.setProperty(*r, "keyboardHeight", jsi::Value(height));
+                 object.setProperty(*r, "keyboardState", jsi::String::createFromUtf8(*r, keyboardState));
+                 object.setProperty(*r, "isKeyboardPresent", jsi::Value(isKeyboardPresent));
                  c->call(*r, std::move(object));
              });
          };

--- a/android/src/main/java/com/reactnativesafeareaime/SafeAreaImeModule.kt
+++ b/android/src/main/java/com/reactnativesafeareaime/SafeAreaImeModule.kt
@@ -5,6 +5,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEm
 import com.facebook.react.uimanager.PixelUtil
 
 
+// Is Deprecated?
 class SafeAreaImeModule(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safe-area-ime",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "test",
   "main": "src/index",
   "module": "src/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,12 +19,25 @@ const SafeAreaIme = NativeModules.SafeAreaIme
 
 SafeAreaIme.install();
 
+export enum KeyboardState {
+  CLOSED = 'CLOSED',
+  OPENING = 'OPENING',
+  OPENED = 'OPENED',
+  CLOSING = 'CLOSED',
+}
+
+export type NativeKeyboardNotificationsListenerParams = {
+  keyboardHeight: number;
+  keyboardState: KeyboardState;
+  isKeyboardPresent: boolean
+}
+export type NativeKeyboardNotificationsListener =
+  (params: NativeKeyboardNotificationsListenerParams) => void
+
 declare global {
   var __safeAreaIme: {
     safeArea(): SafeAreaModel;
-    listenKeyboard(
-      callback: (params: { type: 'show' | 'hide'; height: number }) => void
-    ): void;
+    listenKeyboard(callback: NativeKeyboardNotificationsListener): void;
     stopListenKeyboard(): void;
     toggleFitsSystemWindows(isDisabled: boolean): void;
   };
@@ -44,7 +57,7 @@ export const layout = {
     return global.__safeAreaIme.safeArea();
   },
 
-  listenKeyboard(callback: (params: { type: 'show' | 'hide'; height: number }) => void) {
+  listenKeyboard(callback: NativeKeyboardNotificationsListener) {
     global.__safeAreaIme.listenKeyboard(callback);
   },
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ export enum KeyboardState {
   CLOSED = 'CLOSED',
   OPENING = 'OPENING',
   OPENED = 'OPENED',
-  CLOSING = 'CLOSED',
+  CLOSING = 'CLOSING',
 }
 
 export type NativeKeyboardNotificationsListenerParams = {


### PR DESCRIPTION
## Add and export new Keyboard related TS Types:
- KeyboardState enum (```{
  CLOSED = 'CLOSED',
  OPENING = 'OPENING',
  OPENED = 'OPENED',
  CLOSING = 'CLOSED',
}```)
- NativeKeyboardNotificationsListenerParams ( ```{keyboardHeight: number, keyboardState: KeyboardState (practically an enum), isKeyboardPresent: boolean }```)
- NativeKeyboardNotificationsListener (```(params: NativeKeyboardNotificationsListenerParams) => void```)

## Adjust iOS Keyboard Notifications Handling
- add Helpers (getKeyboardFrame and updateExportModuleKeyboardData)
- fix incorrect _notificationName-to-methodName_ Mapping (_KeyboardWillChangeFrame_ Notification was handled by method called _keyboardDidShow_; _KeyboardWillHide_ Notification was handled by method called _keyboardDidHide_)
- add handlers [_intended_] for _KeyboardWillShow_ and _KeyboardWillHide_
- make listeners callbacks conform to new ```NativeKeyboardNotificationsListenerParams```
- remove excess / not used code

## Make Android Keyboard Notifications conform to new ```NativeKeyboardNotificationsListenerParams```

### Bump Version to 0.8.0